### PR TITLE
Shuffle after each epoch

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -100,9 +100,6 @@ pub fn main() !void {
     while (true
     // current_epoch_index < TRAINING_EPOCHS
     ) : (current_epoch_index += 1) {
-        // Shuffle the data after each epoch
-        shuffle(random_instance, training_data_points, .{});
-
         // Split the training data into mini batches so way we can get through learning
         // iterations faster. It does make the learning progress a bit noisy because the
         // cost landscape is a bit different for each batch but it's fast and apparently
@@ -154,5 +151,8 @@ pub fn main() !void {
                 });
             }
         }
+
+        // Shuffle the data after each epoch
+        shuffle(random_instance, training_data_points, .{});
     }
 }

--- a/src/simple_xy_animal_sample_main.zig
+++ b/src/simple_xy_animal_sample_main.zig
@@ -184,9 +184,6 @@ pub fn main() !void {
     while (true
     //current_epoch_iteration_count < TRAINING_EPOCHS
     ) : (current_epoch_iteration_count += 1) {
-        // Shuffle the data after each epoch
-        shuffle(random_instance, &animal_training_data_points, .{});
-
         // Split the training data into mini batches so way we can get through learning
         // iterations faster. It does make the learning progress a bit noisy because the
         // cost landscape is a bit different for each batch but it's fast and apparently
@@ -245,6 +242,9 @@ pub fn main() !void {
                 allocator,
             );
         }
+
+        // Shuffle the data after each epoch
+        shuffle(random_instance, &animal_training_data_points, .{});
     }
 
     // Graph how the neural network looks at the end of training.


### PR DESCRIPTION
Shuffle after each epoch

Previously, we would shuffle before each epoch which is fine but is not necessary for the first run if the data is already shuffled and gives us random results for the first epoch when we're trying to debug things.