### PR TITLE
Fix initial cost gradient and momentum using undefined initial memory

### DIFF
--- a/src/neural_networks/layer.zig
+++ b/src/neural_networks/layer.zig
@@ -81,10 +81,14 @@ pub const Layer = struct {
         );
 
         var cost_gradient_weights: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
+        @memset(cost_gradient_weights, 0);
         var cost_gradient_biases: []f64 = try allocator.alloc(f64, num_output_nodes);
+        @memset(cost_gradient_biases, 0);
 
         var weight_velocities: []f64 = try allocator.alloc(f64, num_input_nodes * num_output_nodes);
+        @memset(weight_velocities, 0);
         var bias_velocities: []f64 = try allocator.alloc(f64, num_output_nodes);
+        @memset(bias_velocities, 0);
 
         var weighted_input_sums = try allocator.alloc(f64, num_output_nodes);
 


### PR DESCRIPTION
Fix initial cost gradient and momentum using undefined initial memory

Previously, the first gradient descent step would start from undefined memory which in Zig's safe mode, would be `010101010...` repeating for the bit pattern of the `f64` which is some arbitrary float value.

(split out from https://github.com/MadLittleMods/zig-ocr-neural-network/pull/1)