### PR TITLE
Add todos for future improvements

### DIFF
--- a/src/neural_networks/layer.zig
+++ b/src/neural_networks/layer.zig
@@ -400,6 +400,8 @@ pub const Layer = struct {
         // > -- *Deep Learning* book page 296 (Ian Goodfellow)
         momentum: f64,
     ) void {
+        // TODO: Implement weight decay (also known as or similar to "L2 regularization"
+        // or "ridge regression") for purported effects that it "reduces overfitting"
         for (self.weights, 0..) |*weight, weight_index| {
             const velocity = (learn_rate * self.cost_gradient_weights[weight_index]) +
                 (momentum * self.weight_velocities[weight_index]);

--- a/src/simple_xy_animal_sample_main.zig
+++ b/src/simple_xy_animal_sample_main.zig
@@ -200,6 +200,8 @@ pub fn main() !void {
 
             try neural_network.learn(
                 training_batch,
+                // TODO: Implement learn rate decay so we take more refined steps the
+                // longer we train for.
                 LEARN_RATE,
                 MOMENTUM,
                 allocator,


### PR DESCRIPTION
Add todos for future improvements.

Essentially, a couple of features that I saw in C# implementation that makes us different. And since we're trying to figure out why we're not able to see training progress with the same parameters, these could be factors in play.