### PR TITLE
Calculate relative error in gradient check

### DIFF
--- a/src/neural_networks/neural_networks.zig
+++ b/src/neural_networks/neural_networks.zig
@@ -216,7 +216,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
             // randomly/sparingly during training with a small batch
             //
             // Gradient checking to make sure our back propagration algorithm is working correctly
-            const should_gradient_check = true;
+            const should_gradient_check = false;
             if (should_gradient_check) {
                 try self.sanityCheckCostGradients(training_data_batch, allocator);
             }


### PR DESCRIPTION
Calculate relative error in gradient check (tips from https://cs231n.github.io/neural-networks-3/#gradcheck)

Previously, I just did some ratio checking which was effective but calculating relative error seems more bog standard (and probably more familiar to those deep in ML) and I can see look at the ratio of things this way.