### PR TITLE
Document alternative form of the `CrossEntropy` derivative so I don't second guess myself when seeing other implementations

### DIFF
--- a/src/neural_networks/cost_functions.zig
+++ b/src/neural_networks/cost_functions.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 
 // Cost functions are also known as loss functions.
+//
+// Equation references (cost and derivative): https://stats.stackexchange.com/questions/154879/a-list-of-cost-functions-used-in-neural-networks-alongside-applications/154880#154880
 
 // TODO: In the future, we could add negative log likelihood, MeanAbsoluteError (L1 loss),
 // RootMeanSquaredError, Focal Loss,  etc.
@@ -125,7 +127,8 @@ pub const CrossEntropy = struct {
             return 0.0;
         }
 
-        return (-1 * actual_output + expected_output) / (actual_output * (actual_output - 1));
+        // Alternative form: (actual_output - expected_output) / (actual_output * (1 - actual_output))
+        return (expected_output - actual_output) / (actual_output * (actual_output - 1));
     }
 };
 


### PR DESCRIPTION
Document alternative form of the `CrossEntropy` derivative so I don't second guess myself when seeing other implementations


### Math

 - $`A`$: actual
 -  $`E`$: expected

Given expression: $`\frac{E - A}{A \cdot (A - 1)}`$

1. Simplify the numerator:  $`E - A`$

    We can rearrange the terms in the numerator to get:
    
    $`E - A = -(A - E)`$

2.  Simplify the denominator: $`A \cdot (A - 1)`$

    Expanding the denominator, we get:
    
    $`A \cdot (A - 1) = A^2 - A`$

    Rearrange the terms in the denominator to get:

    $`A^2 - A = -A \cdot (1 - A)`$

3. Now the expression becomes:

    $`\frac{E - A}{A \cdot (A - 1)} = \frac{-(A - E)}{-A \cdot (1 - A)} = \frac{A - E}{A \cdot (1 - A)}`$
