### PR TITLE
Add functionality to print MNIST data points (images of digits)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -139,31 +139,31 @@ pub fn main() !void {
             // std.log.debug("layer weights {d:.3}", .{neural_network.layers[1].weights});
             // std.log.debug("layer biases {d:.3}", .{neural_network.layers[1].biases});
 
-            // if (current_epoch_index % 1 == 0 and
-            //     current_epoch_index != 0 and
-            //     batch_index == 0)
-            // {
-            const current_timestamp_seconds = std.time.timestamp();
-            const runtime_duration_seconds = current_timestamp_seconds - start_timestamp_seconds;
-            const duration_string = try time_utils.formatDuration(
-                runtime_duration_seconds * time_utils.ONE_SECOND_MS,
-                allocator,
-            );
-            defer allocator.free(duration_string);
+            if (current_epoch_index % 1 == 0 and
+                current_epoch_index != 0 and
+                batch_index == 0)
+            {
+                const current_timestamp_seconds = std.time.timestamp();
+                const runtime_duration_seconds = current_timestamp_seconds - start_timestamp_seconds;
+                const duration_string = try time_utils.formatDuration(
+                    runtime_duration_seconds * time_utils.ONE_SECOND_MS,
+                    allocator,
+                );
+                defer allocator.free(duration_string);
 
-            const cost = try neural_network.cost_many(testing_data_points, allocator);
-            const accuracy = try neural_network.getAccuracyAgainstTestingDataPoints(
-                testing_data_points,
-                allocator,
-            );
-            std.log.debug("epoch {d: <3} batch {d: <3} {s: >12} -> cost {d}, accuracy with test points {d}", .{
-                current_epoch_index,
-                batch_index,
-                duration_string,
-                cost,
-                accuracy,
-            });
-            // }
+                const cost = try neural_network.cost_many(testing_data_points, allocator);
+                const accuracy = try neural_network.getAccuracyAgainstTestingDataPoints(
+                    testing_data_points,
+                    allocator,
+                );
+                std.log.debug("epoch {d: <3} batch {d: <3} {s: >12} -> cost {d}, accuracy with test points {d}", .{
+                    current_epoch_index,
+                    batch_index,
+                    duration_string,
+                    cost,
+                    accuracy,
+                });
+            }
         }
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,8 +14,7 @@ const NUM_OF_IMAGES_TO_TEST_ON = 100; // (max 10k)
 // The number of times to run through the whole training data set.
 const TRAINING_EPOCHS = 1000;
 const BATCH_SIZE: u32 = 100;
-const INIITIAL_LEARN_RATE: f64 = 0.05;
-const LEARN_RATE_DECAY: f64 = 0.075;
+const LEARN_RATE: f64 = 0.05;
 const MOMENTUM = 0.9;
 
 pub fn main() !void {
@@ -132,7 +131,7 @@ pub fn main() !void {
 
             try neural_network.learn(
                 training_batch,
-                (1.0 / (1.0 + LEARN_RATE_DECAY * @as(f64, @floatFromInt(current_epoch_index)))) * INIITIAL_LEARN_RATE,
+                LEARN_RATE,
                 MOMENTUM,
                 allocator,
             );

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const shuffle = @import("zshuffle").shuffle;
 const mnist_data_utils = @import("mnist/mnist_data_utils.zig");
+const mnist_print_utils = @import("mnist/print_utils.zig");
 const neural_networks = @import("neural_networks/neural_networks.zig");
 const LayerOutputData = @import("neural_networks/layer.zig").LayerOutputData;
 const time_utils = @import("utils/time_utils.zig");
@@ -45,6 +46,7 @@ pub fn main() !void {
         raw_mnist_data.training_images,
         allocator,
     );
+
     defer allocator.free(normalized_raw_training_images);
     const normalized_raw_test_images = try mnist_data_utils.normalizeMnistRawImageData(
         raw_mnist_data.testing_images,
@@ -76,6 +78,15 @@ pub fn main() !void {
         training_data_points.len,
         testing_data_points.len,
     });
+
+    // TODO: See what the images look like
+    const labeled_image_under_test = mnist_data_utils.LabeledImage{
+        .label = training_data_points[0].label,
+        .image = mnist_data_utils.Image{ .normalized_image = .{
+            .pixels = training_data_points[0].inputs[0..(28 * 28)].*,
+        } },
+    };
+    try mnist_print_utils.printLabeledImage(labeled_image_under_test, allocator);
 
     var neural_network = try neural_networks.NeuralNetwork(DigitDataPoint).init(
         &[_]u32{ 784, 100, digit_labels.len },

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,7 +46,6 @@ pub fn main() !void {
         raw_mnist_data.training_images,
         allocator,
     );
-
     defer allocator.free(normalized_raw_training_images);
     const normalized_raw_test_images = try mnist_data_utils.normalizeMnistRawImageData(
         raw_mnist_data.testing_images,
@@ -78,8 +77,8 @@ pub fn main() !void {
         training_data_points.len,
         testing_data_points.len,
     });
-
-    // TODO: See what the images look like
+    // Show what the first image looks like
+    std.log.debug("Here is what the first training data point looks like:", .{});
     const labeled_image_under_test = mnist_data_utils.LabeledImage{
         .label = training_data_points[0].label,
         .image = mnist_data_utils.Image{ .normalized_image = .{
@@ -104,9 +103,6 @@ pub fn main() !void {
         allocator,
     );
     defer neural_network.deinit(allocator);
-
-    std.log.debug("initial layer weights {d:.3}", .{neural_network.layers[1].weights});
-    std.log.debug("initial layer biases {d:.3}", .{neural_network.layers[1].biases});
 
     var current_epoch_index: usize = 0;
     while (true
@@ -147,13 +143,7 @@ pub fn main() !void {
                 allocator,
             );
 
-            // std.log.debug("layer weights {d:.3}", .{neural_network.layers[1].weights});
-            // std.log.debug("layer biases {d:.3}", .{neural_network.layers[1].biases});
-
-            if (current_epoch_index % 1 == 0 and
-                current_epoch_index != 0 and
-                batch_index == 0)
-            {
+            if (batch_index % 5 == 0) {
                 const current_timestamp_seconds = std.time.timestamp();
                 const runtime_duration_seconds = current_timestamp_seconds - start_timestamp_seconds;
                 const duration_string = try time_utils.formatDuration(

--- a/src/mnist/mnist_data_utils.zig
+++ b/src/mnist/mnist_data_utils.zig
@@ -16,16 +16,26 @@ pub const MnistImageFileHeader = extern struct {
 };
 
 pub const RawImageData = [28 * 28]u8;
-pub const NormalizedrawImageData = [28 * 28]f64;
+pub const NormalizedRawImageData = [28 * 28]f64;
 
-pub const Image = extern struct {
+pub const RawImage = struct {
     width: u8 = 28,
     height: u8 = 28,
     pixels: RawImageData,
 };
+pub const NormalizedImage = struct {
+    width: u8 = 28,
+    height: u8 = 28,
+    pixels: NormalizedRawImageData,
+};
+
+pub const Image = union(enum) {
+    raw_image: RawImage,
+    normalized_image: NormalizedImage,
+};
 
 pub const LabelType = u8;
-pub const LabeledImage = extern struct {
+pub const LabeledImage = struct {
     label: LabelType,
     image: Image,
 };
@@ -196,8 +206,8 @@ pub fn getMnistData(
 pub fn normalizeMnistRawImageData(
     raw_images: []const RawImageData,
     allocator: std.mem.Allocator,
-) ![]NormalizedrawImageData {
-    const normalized_raw_images = try allocator.alloc(NormalizedrawImageData, raw_images.len);
+) ![]NormalizedRawImageData {
+    const normalized_raw_images = try allocator.alloc(NormalizedRawImageData, raw_images.len);
     for (raw_images, 0..) |raw_image, image_index| {
         for (raw_image, 0..) |pixel, pixel_index| {
             normalized_raw_images[image_index][pixel_index] = @as(f64, @floatFromInt(pixel)) / 255.0;

--- a/src/mnist/print_utils.zig
+++ b/src/mnist/print_utils.zig
@@ -1,0 +1,218 @@
+const std = @import("std");
+const mnist_data_utils = @import("mnist_data_utils.zig");
+
+/// Add ANSI escape codes to around a given string to make it a certain RGB color in the terminal
+fn decorateStringWithAnsiColor(
+    input_string: []const u8,
+    /// Example: `0xFFFFFF`
+    optional_foreground_hex_color: ?u24,
+    optional_background_hex_color: ?u24,
+    allocator: std.mem.Allocator,
+) ![]const u8 {
+    var foreground_color_code_string: []const u8 = "";
+    if (optional_foreground_hex_color) |foreground_hex_color| {
+        foreground_color_code_string = try std.fmt.allocPrint(
+            allocator,
+            "38;2;{d};{d};{d}",
+            .{
+                // Red channel:
+                // Shift the hex color right 16 bits to get the red component all the way down,
+                // then make sure we only select the lowest 8 bits by using `& 0xFF`
+                (foreground_hex_color >> 16) & 0xFF,
+                // Greeen channel:
+                // Shift the hex color right 8 bits to get the green component all the way down,
+                // then make sure we only select the lowest 8 bits by using `& 0xFF`
+                (foreground_hex_color >> 8) & 0xFF,
+                // Blue channel:
+                // No need to shift the hex color to get the blue component all the way down,
+                // but we still need to make sure we only select the lowest 8 bits by using `& 0xFF`
+                foreground_hex_color & 0xFF,
+            },
+        );
+    }
+    defer allocator.free(foreground_color_code_string);
+
+    var background_color_code_string: []const u8 = "";
+    if (optional_background_hex_color) |background_hex_color| {
+        background_color_code_string = try std.fmt.allocPrint(
+            allocator,
+            "48;2;{d};{d};{d}",
+            .{
+                // Red channel:
+                // Shift the hex color right 16 bits to get the red component all the way down,
+                // then make sure we only select the lowest 8 bits by using `& 0xFF`
+                (background_hex_color >> 16) & 0xFF,
+                // Greeen channel:
+                // Shift the hex color right 8 bits to get the green component all the way down,
+                // then make sure we only select the lowest 8 bits by using `& 0xFF`
+                (background_hex_color >> 8) & 0xFF,
+                // Blue channel:
+                // No need to shift the hex color to get the blue component all the way down,
+                // but we still need to make sure we only select the lowest 8 bits by using `& 0xFF`
+                background_hex_color & 0xFF,
+            },
+        );
+    }
+    defer allocator.free(background_color_code_string);
+
+    var possible_combinator_string: []const u8 = "";
+    if (optional_foreground_hex_color != null and optional_background_hex_color != null) {
+        possible_combinator_string = ";";
+    }
+
+    const string = try std.fmt.allocPrint(
+        allocator,
+        "\u{001b}[{s}{s}{s}m{s}\u{001b}[0m",
+        .{
+            foreground_color_code_string,
+            possible_combinator_string,
+            background_color_code_string,
+            input_string,
+        },
+    );
+
+    return string;
+}
+
+pub const TerminalPrintingCharacter = struct {
+    character: []const u8,
+    /// Some characters render colors differently than others. For example, the full
+    /// block character renders colors as-is but the nedium shade block characters render
+    /// colors at 1/2 strength, etc respectively.
+    opacity_compensation_factor: f64,
+};
+
+// Given a pixel value from 0 to 255, return a unicode block character that represents
+// that pixel value (from nothing, to light shade, to medium shade, to dark shade, to
+// full block).
+//
+// We use this in order to facilitate better copy/pasting from the terminal into a
+// plain-text document like a README, vary the characters so they look different from
+// each other.
+//
+// See https://en.wikipedia.org/wiki/Block_Elements
+fn getCharacterForPixelValue(
+    /// Pixel value between 0.0 and 1.0
+    pixel_value: f64,
+) TerminalPrintingCharacter {
+    var character: []const u8 = undefined;
+    var opacity_compensation_factor: f64 = 1.0;
+    if (pixel_value == 0) {
+        // Just a space character that doesn't render anything but still ends up being
+        // the same width in a monospace environment.
+        character = " ";
+        // opacity = 0.0;
+        // No need to compensate since this character doesn't render any foreground color
+        opacity_compensation_factor = 0.0;
+    } else if (pixel_value < 0.25) {
+        // Light shade character
+        character = "\u{2591}";
+        // opacity = 0.25;
+        // 1 / 0.25 = 4
+        opacity_compensation_factor = 4;
+    } else if (pixel_value < 0.5) {
+        // Medium shade character
+        character = "\u{2592}";
+        // opacity = 0.5;
+        // 1 / 0.5 = 2
+        opacity_compensation_factor = 2;
+    } else if (pixel_value < 0.75) {
+        // Dark shade character
+        character = "\u{2593}";
+        // opacity = 0.75;
+        // 1 / 0.75 = 1.3333...
+        opacity_compensation_factor = @as(f64, 1) / @as(f64, 0.75);
+    } else {
+        // Full block character
+        character = "\u{2588}";
+        // opacity = 1;
+        // 1 / 1 = 1
+        // No need to compensate since anything divided by 1 is itself
+        opacity_compensation_factor = 1;
+    }
+
+    return .{
+        .character = character,
+        .opacity_compensation_factor = opacity_compensation_factor,
+    };
+}
+
+pub fn printImage(image: mnist_data_utils.Image, allocator: std.mem.Allocator) !void {
+    var width: u8 = 0;
+    var height: u8 = 0;
+    switch (image) {
+        inline else => |case| {
+            width = case.width;
+            height = case.height;
+        },
+    }
+
+    std.debug.print("┌", .{});
+    for (0..width) |column_index| {
+        _ = column_index;
+        std.debug.print("──", .{});
+    }
+    std.debug.print("┐\n", .{});
+
+    for (0..height) |row_index| {
+        std.debug.print("│", .{});
+
+        const row_start_index = row_index * width;
+        for (0..width) |column_index| {
+            const index = row_start_index + column_index;
+            var pixel_value: f64 = 0.0;
+            switch (image) {
+                .raw_image => |raw_image| {
+                    pixel_value = @as(f64, @floatFromInt(raw_image.pixels[index])) / 255.0;
+                },
+                .normalized_image => |normalized_image| {
+                    pixel_value = normalized_image.pixels[index];
+                },
+            }
+
+            const pixel_character = getCharacterForPixelValue(pixel_value);
+            const pixel_string = try std.fmt.allocPrint(
+                allocator,
+                // We use the same character twice to make it look more square (still
+                // not perfect though)
+                "{0s}{0s}",
+                .{pixel_character.character},
+            );
+            defer allocator.free(pixel_string);
+
+            // Adjust the pixel value to compensate for the opacity of the block
+            // character that we're using to represent it.
+            const color_channel_value: u8 = @intFromFloat(
+                255 * (pixel_value * pixel_character.opacity_compensation_factor),
+            );
+
+            const colored_pixel_string = try decorateStringWithAnsiColor(
+                pixel_string,
+                // Create a white/grey color with the pixel value copied to every color channel.
+                (@as(u24, color_channel_value) << 16) |
+                    (@as(u24, color_channel_value) << 8) |
+                    (@as(u24, color_channel_value) << 0),
+                0x000000,
+                allocator,
+            );
+            defer allocator.free(colored_pixel_string);
+            std.debug.print("{s}", .{
+                colored_pixel_string,
+            });
+        }
+        std.debug.print("│\n", .{});
+    }
+
+    std.debug.print("└", .{});
+    for (0..width) |column_index| {
+        _ = column_index;
+        std.debug.print("──", .{});
+    }
+    std.debug.print("┘\n", .{});
+}
+
+pub fn printLabeledImage(labeled_image: mnist_data_utils.LabeledImage, allocator: std.mem.Allocator) !void {
+    std.debug.print("┌──────────┐\n", .{});
+    std.debug.print("│ Label: {d} │\n", .{labeled_image.label});
+    try printImage(labeled_image.image, allocator);
+}


### PR DESCRIPTION
Add functionality to print MNIST data points (images of digits).

Spawning from wanting to verify that we were getting incorrect images with this bug: https://github.com/MadLittleMods/zig-ocr-neural-network/pull/12

```sh
$ zig build run-mnist_ocr
debug: training labels header mnist.mnist_data_utils.MnistLabelFileHeader{ .magic_number = 2049, .number_of_labels = 60000 }
debug: training images header mnist.mnist_data_utils.MnistImageFileHeader{ .magic_number = 2051, .number_of_images = 60000, .number_of_rows = 28, .number_of_columns = 28 }
debug: testing labels header mnist.mnist_data_utils.MnistLabelFileHeader{ .magic_number = 2049, .number_of_labels = 10000 }
debug: testing images header mnist.mnist_data_utils.MnistImageFileHeader{ .magic_number = 2051, .number_of_images = 10000, .number_of_rows = 28, .number_of_columns = 28 }
debug: Created normalized data points. Training on 60000 data points, testing on 100
debug: Here is what the first training data point looks like:
┌──────────┐
│ Label: 5 │
┌────────────────────────────────────────────────────────┐
│                                                        │
│                                                        │
│                                                        │
│                                                        │
│                                                        │
│                        ░░░░░░░░▒▒▓▓▓▓░░▓▓████▒▒        │
│                ░░░░▒▒▓▓▓▓████████████▓▓██████▒▒        │
│              ░░████████████████████▒▒▒▒▒▒░░░░          │
│              ░░██████████████▓▓████                    │
│                ▒▒▓▓▒▒██████░░  ░░▓▓                    │
│                  ░░░░▓▓██▒▒                            │
│                      ▓▓██▓▓░░                          │
│                      ░░▓▓██▒▒                          │
│                        ░░████▓▓▒▒░░                    │
│                          ▒▒██████▒▒░░                  │
│                            ░░▓▓████▓▓░░                │
│                              ░░▒▒████▓▓                │
│                                  ██████▒▒              │
│                            ░░▓▓▓▓██████░░              │
│                        ░░▓▓██████████▓▓                │
│                    ░░▒▒████████████▒▒                  │
│                ░░▒▒████████████▒▒░░                    │
│            ░░▓▓████████████▒▒░░                        │
│        ░░▓▓████████████▓▓░░                            │
│        ▓▓████████▓▓▓▓░░                                │
│                                                        │
│                                                        │
│                                                        │
└────────────────────────────────────────────────────────┘
debug: epoch 0   batch 0             3s -> cost 328.2142204682694, accuracy with test points 0.11
debug: epoch 0   batch 5             3s -> cost 251.30090715210744, accuracy with test points 0.59
debug: epoch 0   batch 10            4s -> cost 173.36122442454, accuracy with test points 0.66
debug: epoch 0   batch 15            4s -> cost 129.8505114553166, accuracy with test points 0.75
debug: epoch 0   batch 20            5s -> cost 105.07134500738981, accuracy with test points 0.81
debug: epoch 0   batch 25            5s -> cost 105.9608632207419, accuracy with test points 0.77
debug: epoch 0   batch 30            6s -> cost 82.39684434985433, accuracy with test points 0.86
debug: epoch 0   batch 35            6s -> cost 83.65926200997627, accuracy with test points 0.84
debug: epoch 0   batch 40            7s -> cost 73.3612682266723, accuracy with test points 0.9
debug: epoch 0   batch 45            7s -> cost 67.128872687339, accuracy with test points 0.9
debug: epoch 0   batch 50            8s -> cost 67.1559864272731, accuracy with test points 0.87
debug: epoch 0   batch 55            8s -> cost 60.419791821748404, accuracy with test points 0.9
debug: epoch 0   batch 60            9s -> cost 68.16367181206456, accuracy with test points 0.91
debug: epoch 0   batch 65           10s -> cost 72.91261989070384, accuracy with test points 0.89
debug: epoch 0   batch 70           10s -> cost 66.56112725467558, accuracy with test points 0.88
debug: epoch 0   batch 75           11s -> cost 57.1296321510229, accuracy with test points 0.91
debug: epoch 0   batch 80           11s -> cost 53.324068049268156, accuracy with test points 0.94
debug: epoch 0   batch 85           12s -> cost 58.994979898102656, accuracy with test points 0.91
debug: epoch 0   batch 90           12s -> cost 59.955379827389535, accuracy with test points 0.92
debug: epoch 0   batch 95           13s -> cost 61.057823404098045, accuracy with test points 0.9
debug: epoch 0   batch 100          13s -> cost 60.09789380621815, accuracy with test points 0.91
debug: epoch 0   batch 105          14s -> cost 59.39931113498459, accuracy with test points 0.92
debug: epoch 0   batch 110          14s -> cost 60.6699670573182, accuracy with test points 0.94
debug: epoch 0   batch 115          15s -> cost 60.64345994573608, accuracy with test points 0.95
debug: epoch 0   batch 120          15s -> cost 72.36006328058507, accuracy with test points 0.88
debug: epoch 0   batch 125          16s -> cost 53.412179552102764, accuracy with test points 0.93
debug: epoch 0   batch 130          16s -> cost 59.442174576669935, accuracy with test points 0.91
debug: epoch 0   batch 135          17s -> cost 56.04428797920774, accuracy with test points 0.93
debug: epoch 0   batch 140          17s -> cost 54.68157263217209, accuracy with test points 0.92
debug: epoch 0   batch 145          18s -> cost 54.42738057615533, accuracy with test points 0.93
debug: epoch 0   batch 150          18s -> cost 55.63162536319721, accuracy with test points 0.91
debug: epoch 0   batch 155          19s -> cost 45.82452747354323, accuracy with test points 0.95
debug: epoch 0   batch 160          19s -> cost 44.42105232472584, accuracy with test points 0.95
debug: epoch 0   batch 165          20s -> cost 44.088333809658735, accuracy with test points 0.95
debug: epoch 0   batch 170          20s -> cost 40.13355229280598, accuracy with test points 0.95
debug: epoch 0   batch 175          21s -> cost 42.787379392650614, accuracy with test points 0.94
debug: epoch 0   batch 180          21s -> cost 42.0577175702251, accuracy with test points 0.94
debug: epoch 0   batch 185          22s -> cost 45.6062954782307, accuracy with test points 0.95
debug: epoch 0   batch 190          22s -> cost 45.11378248552181, accuracy with test points 0.93
debug: epoch 0   batch 195          23s -> cost 42.082703233036106, accuracy with test points 0.94
debug: epoch 0   batch 200          23s -> cost 44.775387725682386, accuracy with test points 0.94
debug: epoch 0   batch 205          24s -> cost 45.72341674564558, accuracy with test points 0.93
debug: epoch 0   batch 210          24s -> cost 44.81140819841122, accuracy with test points 0.94
debug: epoch 0   batch 215          25s -> cost 43.838026736115395, accuracy with test points 0.95
debug: epoch 0   batch 220          25s -> cost 45.27871343550334, accuracy with test points 0.92
debug: epoch 0   batch 225          26s -> cost 40.88452173323575, accuracy with test points 0.95
debug: epoch 0   batch 230          26s -> cost 39.83059354665203, accuracy with test points 0.94
debug: epoch 0   batch 235          27s -> cost 36.34680734082054, accuracy with test points 0.95
debug: epoch 0   batch 240          28s -> cost 39.2432921455556, accuracy with test points 0.94
debug: epoch 0   batch 245          28s -> cost 40.18715548816683, accuracy with test points 0.94
debug: epoch 0   batch 250          29s -> cost 39.53532706697054, accuracy with test points 0.93
debug: epoch 0   batch 255          29s -> cost 38.828301360079024, accuracy with test points 0.95
debug: epoch 0   batch 260          30s -> cost 41.305844551934406, accuracy with test points 0.94
```


### Usage

```zig
const labeled_image_under_test = mnist_data_utils.LabeledImage{
    .label = training_data_points[0].label,
    .image = mnist_data_utils.Image{ .normalized_image = .{
        .pixels = training_data_points[0].inputs[0..(28 * 28)].*,
    } },
};
try mnist_print_utils.printLabeledImage(labeled_image_under_test, allocator);
```

```
┌──────────┐
│ Label: 5 │
┌────────────────────────────────────────────────────────┐
│                                                        │
│                                                        │
│                                                        │
│                                                        │
│                                                        │
│                        ░░░░░░░░▒▒▓▓▓▓░░▓▓████▒▒        │
│                ░░░░▒▒▓▓▓▓████████████▓▓██████▒▒        │
│              ░░████████████████████▒▒▒▒▒▒░░░░          │
│              ░░██████████████▓▓████                    │
│                ▒▒▓▓▒▒██████░░  ░░▓▓                    │
│                  ░░░░▓▓██▒▒                            │
│                      ▓▓██▓▓░░                          │
│                      ░░▓▓██▒▒                          │
│                        ░░████▓▓▒▒░░                    │
│                          ▒▒██████▒▒░░                  │
│                            ░░▓▓████▓▓░░                │
│                              ░░▒▒████▓▓                │
│                                  ██████▒▒              │
│                            ░░▓▓▓▓██████░░              │
│                        ░░▓▓██████████▓▓                │
│                    ░░▒▒████████████▒▒                  │
│                ░░▒▒████████████▒▒░░                    │
│            ░░▓▓████████████▒▒░░                        │
│        ░░▓▓████████████▓▓░░                            │
│        ▓▓████████▓▓▓▓░░                                │
│                                                        │
│                                                        │
│                                                        │
└────────────────────────────────────────────────────────┘
```

### Dev notes

Image print utility cribbed from [`MadLittleMods/zig-ocr-mnist-k-nearest-neighbors`](https://github.com/MadLittleMods/zig-ocr-mnist-k-nearest-neighbors/blob/37ab3128edfe916df09c60c2d3f20dfe5b5af2ca/src/print_utils.zig)