### PR TITLE
Use more pointers to avoid copy overhead

### DIFF
--- a/src/graph_visualization/create_portable_pix_map.zig
+++ b/src/graph_visualization/create_portable_pix_map.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 
 /// .ppm
 // TODO: There is probably a better way to do this like printing directly a file.
-pub fn createPortablePixMap(pixels: []u24, width: u32, height: u32, allocator: std.mem.Allocator) ![]const u8 {
+pub fn createPortablePixMap(pixels: []const u24, width: u32, height: u32, allocator: std.mem.Allocator) ![]const u8 {
     var pixel_rows = try std.ArrayList([]const u8).initCapacity(allocator, height);
     defer pixel_rows.deinit();
     for (0..height) |height_index| {

--- a/src/graph_visualization/graph_neural_network.zig
+++ b/src/graph_visualization/graph_neural_network.zig
@@ -42,7 +42,7 @@ pub fn graphNeuralNetwork(
     }
 
     // Draw a ball for every training point
-    for (training_data_points) |data_point| {
+    for (training_data_points) |*data_point| {
         const label = data_point.label;
         var pixel_color: u24 = 0x000000;
         if (std.mem.eql(u8, label, "fish")) {
@@ -81,7 +81,7 @@ pub fn graphNeuralNetwork(
     }
 
     // Draw a ball for every test point
-    for (test_data_points) |data_point| {
+    for (test_data_points) |*data_point| {
         const label = data_point.label;
         var pixel_color: u24 = 0x000000;
         if (std.mem.eql(u8, label, "fish")) {
@@ -134,7 +134,7 @@ fn drawBallOnPixelCanvasForDataPoint(
         width: u32,
         height: u32,
     },
-    data_point: DataPointType,
+    data_point: *const DataPointType,
     ball_size: u32,
     draw_color: u24,
 ) void {

--- a/src/neural_networks/neural_networks.zig
+++ b/src/neural_networks/neural_networks.zig
@@ -148,7 +148,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
             allocator: std.mem.Allocator,
         ) !f64 {
             var correct_count: f64 = 0;
-            for (testing_data_points) |testing_data_point| {
+            for (testing_data_points) |*testing_data_point| {
                 const result = try self.classify(testing_data_point.inputs, allocator);
                 if (DataPointType.checkLabelsEqual(result, testing_data_point.label)) {
                     correct_count += 1;
@@ -161,7 +161,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
         /// Calculate the total cost of the network for a single data point
         pub fn cost_individual(
             self: *Self,
-            data_point: DataPointType,
+            data_point: *const DataPointType,
             allocator: std.mem.Allocator,
         ) !f64 {
             var outputs = try self.calculateOutputs(data_point.inputs, allocator);
@@ -177,7 +177,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
             allocator: std.mem.Allocator,
         ) !f64 {
             var total_cost: f64 = 0.0;
-            for (data_points) |data_point| {
+            for (data_points) |*data_point| {
                 const cost_of_data_point = try self.cost_individual(data_point, allocator);
                 // std.log.debug("cost_of_data_point: {d}", .{cost_of_data_point});
                 total_cost += cost_of_data_point;
@@ -208,7 +208,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
             // Use the backpropagation algorithm to calculate the gradient of the cost function
             // (with respect to the network's weights and biases). This is done for each data point,
             // and the gradients are added together.
-            for (training_data_batch) |data_point| {
+            for (training_data_batch) |*data_point| {
                 try self.updateCostGradients(data_point, allocator);
             }
 
@@ -501,7 +501,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
 
         fn updateCostGradients(
             self: *Self,
-            data_point: DataPointType,
+            data_point: *const DataPointType,
             allocator: std.mem.Allocator,
         ) !void {
             // Feed data through the network to calculate outputs. Save all


### PR DESCRIPTION
Use more pointers to avoid copy overhead

(and hopefully better avoid any future pointer mistakes to stack allocated memory)