### PR TITLE
Use built-in approximately equal test assertion (`std.testing.expectApproxEqAbs(...)`)

### DIFF
--- a/src/neural_networks/activation_functions.zig
+++ b/src/neural_networks/activation_functions.zig
@@ -336,16 +336,8 @@ test "Slope check activation functions" {
 
         // Check to make sure the actual slope is within a certain threshold of the
         // estimated slope
-        const threshold = 0.0001;
-        if (@fabs(estimated_slope - actual_slope) > threshold) {
-            std.debug.print("{s}: Expected actual slope {d} to be within {d} of the estimated slope: {d} (which we assume to ~correct)\n", .{
-                activation_function.getName(),
-                actual_slope,
-                threshold,
-                estimated_slope,
-            });
-            return error.FaultySlope;
-        }
+        const threshold = 1e-4;
+        try std.testing.expectApproxEqAbs(estimated_slope, actual_slope, threshold);
     }
 }
 

--- a/src/neural_networks/cost_functions.zig
+++ b/src/neural_networks/cost_functions.zig
@@ -280,18 +280,8 @@ test "Slope check cost functions" {
 
         // Check to make sure the actual slope is within a certain threshold of the
         // estimated slope
-        const threshold = 0.0001;
-        if (@fabs(estimated_slope - actual_slope) > threshold) {
-            std.debug.print("{s}({d}, {d}): Expected actual slope {d} to be within {d} of the estimated slope: {d} (which we assume to ~correct)\n", .{
-                cost_function.getName(),
-                actual_output,
-                expected_output,
-                actual_slope,
-                threshold,
-                estimated_slope,
-            });
-            return error.FaultySlope;
-        }
+        const threshold = 1e-4;
+        try std.testing.expectApproxEqAbs(estimated_slope, actual_slope, threshold);
     }
 }
 

--- a/src/neural_networks/neural_networks.zig
+++ b/src/neural_networks/neural_networks.zig
@@ -298,14 +298,14 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
                     // >  - 1e-7 and less you should be happy.
                     // >
                     // > -- https://cs231n.github.io/neural-networks-3/#gradcheck
-                    if (relative_error > 0.01) {
+                    if (relative_error > 1e-2) {
                         std.log.err("Relative error for index {d} in {s} gradient was too high ({d}).", .{
                             gradient_index,
                             gradient_to_compare.gradient_name,
                             relative_error,
                         });
                         was_relative_error_too_high = true;
-                    } else if (relative_error > 0.0001) {
+                    } else if (relative_error > 1e-4) {
                         // > Note that it is possible to know if a kink was crossed in the
                         // > evaluation of the loss. This can be done by keeping track of
                         // > the identities of all "winners" in a function of form max(x,y);
@@ -324,16 +324,15 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
                         });
                     }
 
-                    const difference_from_found_error = @fabs(relative_error - found_relative_error);
                     if (
                     // Compare the error to the first non-zero error we found. If the
                     // error is too different then that's suspect since we would expect
                     // the error to be the same for all weights/biases.
-                    difference_from_found_error > 0.0001 and
-                        // We can also sanity check that the error is close to 0 since
-                        // that means the estimated and actual cost gradients are
+                    std.math.approxEqAbs(relative_error, found_relative_error, 1e-4) and
+                        // We can also sanity check whether the error is close to 0
+                        // since that means the estimated and actual cost gradients are
                         // roughly the same.
-                        relative_error > 0.0001)
+                        relative_error > 1e-4)
                     {
                         has_uneven_cost_gradient = true;
                     }
@@ -355,7 +354,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
                     test_layer.cost_gradient_biases,
                 });
                 return error.UnableToFindRelativeErrorOfEstimatedToActualGradient;
-            } else if (found_relative_error > 0.0001) {
+            } else if (found_relative_error > 1e-4) {
                 const uneven_error_message = "The relative error is the different across the entire gradient which " ++
                     "means the gradient is pointing in a totally different direction than it should. " ++
                     "Our backpropagation algorithm is probably wrong.";

--- a/src/neural_networks/neural_networks.zig
+++ b/src/neural_networks/neural_networks.zig
@@ -328,7 +328,7 @@ pub fn NeuralNetwork(comptime DataPointType: type) type {
                     // Compare the error to the first non-zero error we found. If the
                     // error is too different then that's suspect since we would expect
                     // the error to be the same for all weights/biases.
-                    std.math.approxEqAbs(relative_error, found_relative_error, 1e-4) and
+                    std.math.approxEqAbs(f64, relative_error, found_relative_error, 1e-4) and
                         // We can also sanity check whether the error is close to 0
                         // since that means the estimated and actual cost gradients are
                         // roughly the same.


### PR DESCRIPTION
Use built-in approximately equal test assertion (`std.testing.expectApproxEqAbs(...)`)


### Dev notes

`std.testing.expectApproxEqAbs(...)` vs `std.testing.expectApproxEqRel(...)`

Should we be using `math.approxEqAbs(...)`/`math.approxEqRel(...)` in other places where we want to check things are approximately equal? Yes, seems applicable in one spot