### PR TITLE
Better enforce Zig version so people don't run into random roadblocks

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,9 +1,38 @@
 const std = @import("std");
 
+// Other example: std.SemanticVersion{ .major = 0, .minor = 12, .patch = 0, .pre = "dev.890" }
+pub const min_zig_version = std.SemanticVersion{ .major = 0, .minor = 11, .patch = 0 };
+
+// via https://github.com/michal-z/zig-gamedev/blob/48fbe3ed3ceb5626c635d59d4c5503346d5ccb85/build.zig#L320-L341
+fn ensureZigVersion() !void {
+    var installed_ver = @import("builtin").zig_version;
+    installed_ver.build = null;
+
+    if (installed_ver.order(min_zig_version) == .lt) {
+        std.log.err("\n" ++
+            \\---------------------------------------------------------------------------
+            \\
+            \\Installed Zig compiler version is too old.
+            \\
+            \\Min. required version: {any}
+            \\Installed version: {any}
+            \\
+            \\Please install newer version and try again.
+            \\Newer versions can be found here: https://ziglang.org/download/
+            \\
+            \\---------------------------------------------------------------------------
+            \\
+        , .{ min_zig_version, installed_ver });
+        return error.ZigIsTooOld;
+    }
+}
+
 // Although this function looks imperative, note that its job is to
 // declaratively construct a build graph that will be executed by an external
 // runner.
 pub fn build(b: *std.Build) !void {
+    try ensureZigVersion();
+
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
     // means any target is allowed, and the default is native. Other options


### PR DESCRIPTION
Better enforce Zig version so people don't run into random roadblocks

Unfortunately, if you use an older version of Zig, there are other API differences in the build system that will pop up instead of our nice error message. But hopefully we can bring this pattern with us into the future. Also would be good to define a maximum version at some point.