### PR TITLE
Document how the SoftMax activation and deriative are derived

### DIFF
--- a/dev-notes.md
+++ b/dev-notes.md
@@ -160,6 +160,102 @@ TODO: Chain rule for how these are derived (chain rule tree reference: https://y
 
 When expanding the network with more nodes per layer, TODO
 
+### Activation functions
+
+#### Softmax
+
+Sources:
+
+ - Help from Hans Musgrave
+ - [*Softmax Layer from Scratch | Mathematics & Python
+   Code*](https://youtu.be/AbLvJVwySEo?si=uhGygTuChG8xMjGV&t=181) by The Independent
+   Code
+ - Dahal, Paras. (Jun 2017). [Softmax and Cross Entropy Loss. Paras Dahal.](https://www.parasdahal.com/softmax-crossentropy#derivative-of-softmax)
+
+Given the SoftMax equation:
+$`
+y_i = \frac{e^{x_i}}{\sum\limits_{j=1}^{n} e^{x_j}}
+= \frac{\verb|exp_input|}{\verb|exp_sum|}
+`$
+
+We can use the quotient rule ($`(\frac{u}{v})' = \frac{u'v - uv'}{v^2}`$) to
+find the derivative of the SoftMax equation with respect to a
+specific element of the input vector ($`x_k`$):
+
+For convenience, let $`\delta_{ik}`$ denote a symbol meaning $`1`$ if $`i = k`$ and $`0`$ otherwise.
+
+$`
+\begin{aligned}
+\delta_{ik} &= {\begin{cases}
+    1 & \text{if } i = k\\
+    0 & \text{otherwise.}
+\end{cases}}
+\\
+\\
+\frac{\partial y_i}{\partial x_k} &=
+\frac{
+    \delta_{ik}e^{x_i}(\sum\limits_{j=1}^{n} e^{x_j}) - e^{x_i}e^{x_k}
+}
+{
+    (\sum\limits_{j=1}^{n} e^{x_j})^2
+}
+\\&=
+y_i\delta_{ik} - y_iy_k
+\end{aligned}`$
+
+Or if we want to split up that delta (δ) condition, we will get:
+
+$`\begin{aligned}
+\text{If } k = i \text{:}
+\\
+\frac{\partial y_i}{\partial x_k} &=
+\frac{
+    e^{x_i}(\sum\limits_{j=1}^{n} e^{x_j}) - e^{x_i}e^{x_i}
+}
+{
+    (\sum\limits_{j=1}^{n} e^{x_j})^2
+}
+= \frac{\verb|exp_input| * \verb|exp_sum| - \verb|exp_input| * \verb|exp_input|}{\verb|exp_sum| * \verb|exp_sum|}
+\\&=
+\frac{e^{x_i}}{\sum\limits_{j=1}^{n} e^{x_j}} -
+(\frac{e^{x_i}}{\sum\limits_{j=1}^{n} e^{x_j}})^2
+\\&=
+y_i - (y_i)^2
+\\&=
+y_i(1 - y_i)
+\end{aligned}`$
+
+$`\begin{aligned}
+\text{If } k \ne i \text{:}
+\\
+\frac{\partial y_i}{\partial x_k} &=
+e^{x_i}\frac{-e^{x_k}}{(\sum\limits_{j=1}^{n} e^{x_j})^2}
+\\&=
+-\frac{e^{x_i}}{\sum\limits_{j=1}^{n} e^{x_j}}\frac{e^{x_k}}{\sum\limits_{j=1}^{n} e^{x_j}}
+\\&=
+-y_iy_k
+\end{aligned}`$
+
+
+
+## Other nerual network implementations
+
+ - https://github.com/SebLague/Neural-Network-Experiments
+    - This codebase has a great video going over all of the details/implementation of the
+      code: https://www.youtube.com/watch?v=hfMk-kjRv4c
+ - https://github.com/hmusgrave/zsmallnet
+ - https://github.com/albert-yu/mnist
+ - https://github.com/yettinmoor/mnist
+ - https://github.com/SilasMarvin/dnns-from-scratch-in-zig/
+    - Associated article: https://monadmonkey.com/dnns-from-scratch-in-zig
+ - https://github.com/garrisonhh/perceptron
+ - https://github.com/Deins/zig-nnet
+    - Has lots of nice comments
+ - https://github.com/star-tek-mb/mnist-predictor
+ - Python and NumPy: https://github.com/TheIndependentCode/Neural-Network
+    - This codebase has a whole YouTube series behind it, ex. [*Softmax Layer from Scratch | Mathematics & Python Code*](https://www.youtube.com/watch?v=AbLvJVwySEo)
+
+
 
 ## Zig
 

--- a/src/neural_networks/activation_functions.zig
+++ b/src/neural_networks/activation_functions.zig
@@ -151,15 +151,24 @@ pub const Sigmoid = struct {
 // 1. So in terms of usage, this function will tell you what percentage that the
 // given value at the `input_index` makes up the total sum of all the values in the
 // array.
+
+/// SoftMax is basically the multi-dimensional version of Sigmoid. See the [developer
+/// notes on SoftMax](../../dev-notes.md) to see how the equation is derived.
 //
 // TODO: Visualize this (ASCII art)
 // TODO: Why would someone use this one?
-// https://machinelearningmastery.com/softmax-activation-function-with-python/
+//
+// Resources:
+//  - Dahal, Paras. (Jun 2017). Softmax and Cross Entropy Loss. Paras Dahal.
+//    https://parasdahal.com/softmax-crossentropy.
+//  - Softmax Layer from Scratch | Mathematics & Python Code (by The Independent Code),
+//    https://www.youtube.com/watch?v=AbLvJVwySEo
+//  - https://themaverickmeerkat.com/2019-10-23-Softmax/
 pub const SoftMax = struct {
     pub fn activate(_: @This(), inputs: []const f64, input_index: usize) f64 {
         // TODO: Since it's really easy for the exponents to exceed the max value of a
         // float, we could subtract the max value from each input to make sure we don't
-        // overflow (numerically stable): `@exp(input - max(input))` (do this if we ever
+        // overflow (numerically stable): `@exp(input - max(inputs))` (do this if we ever
         // start seeing NaNs)
 
         var exp_sum: f64 = 0.0;
@@ -169,9 +178,12 @@ pub const SoftMax = struct {
 
         const exp_input = @exp(inputs[input_index]);
 
+        // SoftMax equation: f(x) = e^x / Σ(e^x)
         return exp_input / exp_sum;
     }
 
+    // Partial derivative of the activation function with respect to the input at the
+    // given index (x_k).
     pub fn derivative(_: @This(), inputs: []const f64, input_index: usize) f64 {
         var exp_sum: f64 = 0.0;
         for (inputs) |input| {
@@ -180,6 +192,11 @@ pub const SoftMax = struct {
 
         const exp_input = @exp(inputs[input_index]);
 
+        // See the [developer notes on SoftMax](../../dev-notes.md#softmax) to
+        // see how the equation is derived.
+        //
+        // TODO: Why can we get away with only using the k = i version of the
+        // equation? Is this flawed?
         return (exp_input * exp_sum - exp_input * exp_input) / (exp_sum * exp_sum);
     }
 };


### PR DESCRIPTION
Document how the SoftMax activation and deriative are derived

Related to https://github.com/MadLittleMods/zig-ocr-neural-network/issues/15

Split out from https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20