### PR TITLE
Make it more obvious that pieces in the hidden layer calculation are from the next layer

### DIFF
--- a/dev-notes.md
+++ b/dev-notes.md
@@ -124,21 +124,22 @@ a_1 &\times&
 
 The partial derivative of cost with respect to the **weight** of the 1st connection.
 (the parts in green are the pieces we're calculating in
-`calculateHiddenLayerShareableNodeDerivatives(...)`)
+`calculateHiddenLayerShareableNodeDerivatives(...)`, the parts in blue come from
+`next_layer_shareable_node_derivatives` that are passed into the function)
 
 $`\begin{aligned}
 \frac{\partial c}{\partial w_1} &=
 \frac{\partial z_1}{\partial w_1} &\times&
 \color{#008b6c}{\frac{\partial a_1}{\partial z_1}} &\times&
 \color{#008b6c}{\frac{\partial z_2}{\partial a_1}} &\times&
-\color{#008b6c}{\frac{\partial a_2}{\partial z_2}} &\times&
-\color{#008b6c}{\frac{\partial c}{\partial a_2}}
+\color{#107bc3}{\frac{\partial a_2}{\partial z_2}} &\times&
+\color{#107bc3}{\frac{\partial c}{\partial a_2}}
 \\&=
 a_0 &\times&
 \color{#008b6c}{\verb|activation_function.derivative|(z_1)} &\times&
 \color{#008b6c}{w_2} &\times&
-\color{#008b6c}{\verb|activation_function.derivative|(z_2)}  &\times&
-\color{#008b6c}{\verb|cost_function.derivative|(a_2, \mathrm{expected\_output})}
+\color{#107bc3}{\verb|activation_function.derivative|(z_2)}  &\times&
+\color{#107bc3}{\verb|cost_function.derivative|(a_2, \mathrm{expected\_output})}
 \end{aligned}`$
 
 The partial derivative of cost with respect to **bias** of the 2nd node. (this applies


### PR DESCRIPTION
Make it more obvious that pieces in the hidden layer calculation are from the next layer.

And better matches the source material:

https://youtu.be/hfMk-kjRv4c?si=HABynqn6dcX1EFMA&t=2189
![](https://github.com/MadLittleMods/zig-ocr-neural-network/assets/558581/57f505a2-7823-44ee-95c5-1b9118927e91)
