### PR TITLE
Rename `gradient(...)` to `jacobian_row(...)` for better clarity

### DIFF
--- a/dev-notes.md
+++ b/dev-notes.md
@@ -174,12 +174,12 @@ scalar value with whatever we need to afterwards without thinking about it.
 ---
 
 Note: You might only care about this section if you're trying to figure out why we need
-a `gradient` function for `SoftMax` or are trying to understand the code in
+a `jacobian_row` function for `SoftMax` or are trying to understand the code in
 `calculateOutputLayerShareableNodeDerivatives(...)`. It's mainly just to illustrate a
 point for comparison with the derivative of multi-input activation functions like
 `SoftMax` explained in the section below.
 
-We don't need to specify a `gradient` function for single-input activation functions. We
+We don't need to specify a `jacobian_row` function for single-input activation functions. We
 can simply use the `derivative` with a single-input activation functions.
 
 This characteristic can be conveyed by using a Jacobian matrix to get the derivative of
@@ -329,7 +329,7 @@ $`\begin{bmatrix}
 \frac{\partial y_4}{\partial x_1} & \frac{\partial y_4}{\partial x_4} & \frac{\partial y_4}{\partial x_3} & \frac{\partial y_4}{\partial x_4}\\
 \end{bmatrix}`$
 
-In the context of the code, the `derivative`/`gradient` functions assemble a single row
+In the context of the code, the `derivative`/`jacobian_row` functions assemble a single row
 of this matrix at a time. The row is specified by the `node_index` which ends up getting
 passed in as the `input_index` with the activation functions.
 
@@ -354,7 +354,7 @@ from activation function `derivative` by the partial derivative of the cost with
 to the input of that node (($`\frac{\partial C}{\partial y_i}`$)).
 
 But when using a multi-input activation function like `SoftMax`, we need to take dot
-product the activation `gradient` with the whole cost vector ($`\frac{\partial
+product the activation `jacobian_row` with the whole cost vector ($`\frac{\partial
 C}{\partial y}`$). Remember, we're showing a whole matrix here, but the code just takes
 it row by row (specified by the `node_index` which ends up getting passed in as the
 `input_index` with the activation functions).

--- a/src/neural_networks/layer.zig
+++ b/src/neural_networks/layer.zig
@@ -427,7 +427,7 @@ pub const Layer = struct {
                     // for the activation function.
                     //
                     // da_2/dz_2 = activation_function.derivative(z_2)
-                    const activation_ki_derivatives = try self.activation_function.gradient(
+                    const activation_ki_derivatives = try self.activation_function.jacobian_row(
                         self.layer_output_data.weighted_input_sums,
                         node_index,
                         allocator,
@@ -435,10 +435,12 @@ pub const Layer = struct {
                     defer allocator.free(activation_ki_derivatives);
 
                     // This is just a dot product of the `activation_ki_derivatives` and
-                    // `cost_derivatives` (both vectors).
-                    for (activation_ki_derivatives, 0..) |_, gradient_index| {
-                        shareable_node_derivatives[node_index] += activation_ki_derivatives[gradient_index] *
-                            cost_derivatives[gradient_index];
+                    // `cost_derivatives` (both vectors). Or can also be thought of as a
+                    // matrix multiplication between a 1xn matrix
+                    // (activation_ki_derivatives) and a nx1 matrix (cost_derivatives).
+                    for (activation_ki_derivatives, 0..) |_, activation_derivative_index| {
+                        shareable_node_derivatives[node_index] += activation_ki_derivatives[activation_derivative_index] *
+                            cost_derivatives[activation_derivative_index];
                     }
                 },
             }


### PR DESCRIPTION
Rename `gradient(...)` to `jacobian_row(...)` for better clarity and not to confuse "gradient" with "cost gradient" things.

Follow-up to https://github.com/MadLittleMods/zig-ocr-neural-network/pull/20